### PR TITLE
feat: auto archive QOTD threads

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,11 @@ A small utility Discord bot for the Pacific Northwest Furries server.
 
 Currently the following utilities are implemented:
 - Member welcome messages on membership approval
+- Automatically archive threads in specified Question of the Day channel
+
+The following environment variables are required for configuring bot functionality:
+- `DISCORD_TOKEN`: The bot authentication token
+- `CHANNEL_WELCOME`: The channel that welcome messages should be sent in
+- `ROLE_MEMBER`: The role that will be assigned to approved members
+- `QOTD_CHANNELS`: The channels that threads will be automatically archived in
+- `QOTD_MAX_AGE`: The time that a thread needs to be inactive before it will be archived

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -1,4 +1,4 @@
-import { secret, strictVerify } from "env-verifier"
+import { secret, strictVerify, transform } from "env-verifier"
 
 const env = strictVerify({
   token: secret("DISCORD_TOKEN"),
@@ -7,6 +7,10 @@ const env = strictVerify({
   },
   roles: {
     member: "ROLE_MEMBER"
+  },
+  qotd: {
+    channels: transform("QOTD_CHANNELS",v => v.split(/(,\w*)/)),
+    maxAge: transform("QOTD_MAX_AGE", Number)
   }
 })
 

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -9,7 +9,7 @@ const env = strictVerify({
     member: "ROLE_MEMBER"
   },
   qotd: {
-    channels: transform("QOTD_CHANNELS",v => v.split(/(,\w*)/)),
+    channels: transform("QOTD_CHANNELS",v => v.split(/,\s*/)),
     maxAge: transform("QOTD_MAX_AGE", Number)
   }
 })

--- a/src/events/guildCreate.ts
+++ b/src/events/guildCreate.ts
@@ -1,8 +1,8 @@
 import { Client } from "oceanic.js"
 
-const init = (bot: Client): void => {
-  bot.once("ready", () => {
-    bot.guilds.forEach(async g => {
+const init = (client: Client): void => {
+  client.once("ready", () => {
+    client.guilds.forEach(async g => {
       await g.fetchMembers()
       console.log(`Cached members from ${g.name} (${g.id})`)
     })

--- a/src/events/index.ts
+++ b/src/events/index.ts
@@ -2,10 +2,12 @@ import { Client } from "oceanic.js"
 
 import guildCreate from "./guildCreate"
 import memberVerified from "./memberVerified"
+import qotdArchive from "./qotdArchive"
 
-const init = (client: Client): void => {
-  guildCreate.init(client)
-  memberVerified.init(client)
+const init = async (client: Client): Promise<void> => {
+  await guildCreate.init(client)
+  await memberVerified.init(client)
+  await qotdArchive.init(client)
 }
 
 export default {

--- a/src/events/qotdArchive.ts
+++ b/src/events/qotdArchive.ts
@@ -1,0 +1,54 @@
+import { Base, Client } from "oceanic.js"
+
+import env from "../config/env"
+
+const ARCHIVE_INTERVAL = 60 * 1000
+
+const init = async (client: Client): Promise<void> => {
+  // Convert max age from minutes to ms
+  const maxInactiveTime = env.qotd.maxAge * 60 * 1000
+
+  const archiveTask = async () => {
+    // The initial date that all threads will be compared to
+    const now = new Date()
+
+    // Since threads aren't cached how we'd expect, fetch the active threads for each guild and iterate over the results
+    for (const [ _, guild ] of client.guilds) {
+
+      const activeThreads = await guild.getActiveThreads()
+
+      for (const thread of activeThreads.threads) {
+        // Check if the thread is in a QOTD channel
+        if (!env.qotd.channels.includes(thread.parentID)) {
+          continue
+        }
+
+        // If there's for some reason no messages in the thread, use its creation date as the timestamp for last
+        // activity
+        const lastId = thread.lastMessageID ?? thread.id
+        const lastActive = Base.getCreatedAt(lastId)
+
+        // Get the millis since the thread was last active
+        const timeSinceActive = now.getTime() - lastActive.getTime()
+
+        // If the thread has been inactive longer than the allowed time, archive it.
+        if (timeSinceActive > maxInactiveTime) {
+          console.log(`[QOTD Archive] Archived ${thread.name} (${thread.id})`)
+          await thread.edit({
+            archived: true
+          })
+        }
+      }
+    }
+  }
+
+  // Run the archive task on a set interval
+  setInterval(archiveTask, ARCHIVE_INTERVAL)
+
+  // Run the task once the bot is ready
+  client.once("ready", archiveTask)
+}
+
+export default {
+  init
+}

--- a/src/util/typeguards.ts
+++ b/src/util/typeguards.ts
@@ -1,0 +1,5 @@
+import { AnyChannel, ChannelTypes, ForumChannel } from "oceanic.js"
+
+export const isForumChannel = (channel?: AnyChannel): channel is ForumChannel => {
+  return channel == null ? false : channel.type === ChannelTypes.GUILD_FORUM
+}


### PR DESCRIPTION
This pull request adds the ability for the bot to automatically archive inactive threads in specified channels. This adds two new configuration env vars:
- `QOTD_CHANNELS`: The channels that threads will be automatically archived in
- `QOTD_MAX_AGE`: The time that a thread needs to be inactive before it will be archived